### PR TITLE
parallelize index range scanning

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -48,7 +48,12 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.accumulo.AccumuloErrorCode.INTERNAL_ERROR;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -380,7 +380,7 @@ public class IndexLookup
             Collection<Range> rowIDRanges)
             throws TableNotFoundException, ExecutionException, InterruptedException
     {
-        final Set<Range> finalRanges = new HashSet<>();
+        Set<Range> finalRanges = new HashSet<>();
         // For each column/constraint pair we submit a task to scan the index ranges
         List<Callable<Set<Range>>> tasks = new ArrayList<>();
         for (Entry<AccumuloColumnConstraint, Collection<Range>> e : constraintRanges.asMap().entrySet()) {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchScanner;


### PR DESCRIPTION
currently we scan accumulo in serial for each indexed columns if there are predicators pushed down, in order to reduce index range scanning time we will submit all the scanning tasks to execution service to scan in parallel and wait for all the results come back.
